### PR TITLE
商品管理　画像投稿機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,6 @@ end
 gem 'devise'
 
 gem 'pry-rails'
+
+gem 'mini_magick'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,9 @@ GEM
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -116,6 +119,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.4)
     minitest (5.19.0)
@@ -202,6 +206,8 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.12.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     ruby_dep (1.5.0)
     rubyzip (2.3.2)
     sass (3.7.4)
@@ -271,8 +277,10 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4)
   pg
   pry-rails

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -18,8 +18,8 @@ class MessagesController < ApplicationController
 
   private
 
- def message_params
-   params.require(:message).permit(:content).merge(user_id: current_user.id)
- end
+  def message_params
+  params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
 
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,7 @@
 class Message < ApplicationRecord
   belongs_to :room
   belongs_to :user
+  has_one_attached :image
 
   validates :content, presence: true
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,5 +3,9 @@ class Message < ApplicationRecord
   belongs_to :user
   has_one_attached :image
 
-  validates :content, presence: true
+	validates :content, presence: true, unless: :was_attached?
+
+  def was_attached?
+    self.image.attached?
+  end
 end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -14,6 +14,6 @@
       <!-- 投稿したメッセージ内容を記述する -->
       <%= message.content %>
     </div>
-    <%= image_tag message.image, class: 'message-image' if message.image.attached? %>
+    <%= image_tag message.image.variant(resize: '500x500'), class: 'message-image' if message.image.attached? %>
   </div>
 </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -14,5 +14,6 @@
       <!-- 投稿したメッセージ内容を記述する -->
       <%= message.content %>
     </div>
+    <%= image_tag message.image, class: 'message-image' if message.image.attached? %>
   </div>
 </div>

--- a/db/migrate/20230828004256_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20230828004256_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_25_023752) do
+ActiveRecord::Schema.define(version: 2023_08_28_004256) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "messages", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.string "content"
@@ -54,6 +75,7 @@ ActiveRecord::Schema.define(version: 2023_08_25_023752) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "messages", "rooms"
   add_foreign_key "messages", "users"
   add_foreign_key "room_users", "rooms"


### PR DESCRIPTION
## 変更の概要

* Active Storageの導入
85e48cef5d1eb63df2ebd3011c9d07055322a92d
a75682677a18d84ae285dcaa3fd39e4ed97896c0
* 保存した画像の表示
f9b02190d9e0c8498b35e1267563ac07b432b0f6

## なぜこの変更をするのか

* 画像投稿を可能にして、商品リストを分かりやすい内容にするため。

## やったこと

* [x] 画像加工ツール導入
* [x] Active Storageの導入
* [x] 保存した画像の表示
* [x] 画像サイズの調整
* [x] 画像のみでもメッセージ送信可能となるバリデーションの設定

## 影響範囲

* ユーザーに影響すること
画像投稿を可能にすることで、商品内容の概要が分かりやすい
* メンバーに影響すること
Active Storageの導入によって、テーブルの増加
* システムに影響すること
画像管理の増加

## どうやるのか

* 使い方
商品投稿欄の画像ボタンから画像投稿
画像のみ、テキストのみでも投稿可能