### PR TITLE
Userテストコード修正

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,6 +18,7 @@ ja:
         nickname: "ニックネーム"
         email: "メールアドレス"
         password: "パスワード"
+        password_confirmation: "パスワード再入力"
       room:
         name: "ルーム名"
       message:
@@ -34,8 +35,14 @@ ja:
               blank: "を入力してください"
             email:
               blank: "を入力してください"
+              taken: "メールアドレスはすでに存在します"
+              invalid: "メールアドレスは無効です"
             password:
               blank: "を入力してください"
+              too_short: "は%{count}文字以上で入力してください"
+              confirmation: "が一致しません"
+            password_confirmation:
+              confirmation: "が一致しません"
         room:
           attributes:
             name:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe User, type: :model do
       it 'ニックネームが空では登録できない' do
         @user.nickname = '' # 空のニックネーム設定
         @user.valid?
-        expect(@user.errors[:nickname]).to include("can't be blank")
+        expect(@user.errors[:nickname]).to include("を入力してください")
       end
 
       it 'メールアドレスが空では登録できない' do
         @user.email = '' # 空のメールアドレス設定
         @user.valid?
-        expect(@user.errors[:email]).to include("can't be blank")
+        expect(@user.errors[:email]).to include("を入力してください")
       end
 
       it '重複したメールアドレスが存在する場合は登録できない' do
@@ -30,27 +30,28 @@ RSpec.describe User, type: :model do
         another_user = FactoryBot.build(:user, email: @user.email)
         another_user.save
         if another_user.errors.has_key?(:email)
-          expect(another_user.errors.full_messages).to include('Email has already been taken')
+          expect(another_user.errors[:email]).to include('メールアドレスはすでに存在します')
         end
       end
 
       it 'メールアドレスは@を含まないと登録できない' do
         @user.email = 'testmail' # @を含まないメールアドレス設定
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors[:email]).to include('メールアドレスは無効です')
       end
 
       it 'パスワードが空では登録できない' do
         @user.password = '' # 空のパスワード設定
+        @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors[:password]).to include("を入力してください")
       end
 
       it 'パスワードが5文字以下では登録できない' do
         @user.password = '00000' # 5桁のパスワード設定
         @user.password_confirmation = '00000' # 5桁のパスワード再入力設定
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors[:password]).to include('は6文字以上で入力してください')
       end
 
       it 'パスワードは、半角英字での入力が必須であること' do
@@ -75,7 +76,7 @@ RSpec.describe User, type: :model do
         @user.password = '123456' # 6桁のパスワード設定
         @user.password_confirmation = '1234567' # 7桁のパスワード設定
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors[:password_confirmation]).to include("が一致しません")
       end
 
     end


### PR DESCRIPTION
## 変更の概要

* テストコードエラーメッセージの日本語化

## なぜこの変更をするのか

* エラーが出た時に、どの部分のエラーなのかを理解できるようにするため

## やったこと

* [x] user新規登録のテストコードエラーメッセージの日本語化

## 影響範囲

* ユーザーに影響すること
日本語化することで、どの部分にエラーが出ているか分かりやすくなる
* メンバーに影響すること
ja.ymlにメッセージ入力の作業増
* システムに影響すること
今後テストコードを追加実装する時に、ja.ymlにメッセージを追加する必要有り